### PR TITLE
task :  get articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -129,7 +129,7 @@ describe("/api/articles", () => {
           expect(article.article_id).toBe(2);
         });
     });
-    test("GET 404: responds with 400 and msg 'not found' if out of range query sent", () => {
+    test("GET 404: responds with 404 and msg 'not found' if out of range query sent", () => {
       return request(app)
         .get("/api/articles/9999")
         .expect(404)
@@ -144,6 +144,52 @@ describe("/api/articles", () => {
         .then(({ body }) => {
           expect(body.msg).toBe("bad request");
         });
+    });
+  });
+  describe("/api/articles", () => {
+    describe("GET", () => {
+      test("GET 200: responds with 200 status", () => {
+        return request(app).get("/api/articles").expect(200);
+      });
+      test("GET 200: responds with array of all articles, length 13", () => {
+        return request(app)
+          .get("/api/articles")
+          .expect(200)
+          .then(({ body }) => {
+            const { articles } = body;
+            expect(articles.length).toBe(13);
+          });
+      });
+      test("GET 200: responds with array of articles each having author, title, article_id, topic, created_at, votes, article_img_url, comment_count properties ", () => {
+        return request(app)
+          .get("/api/articles")
+          .expect(200)
+          .then(({ body }) => {
+            const { articles } = body;
+            expect(articles.length).toBe(13);
+            articles.forEach((article) => {
+              expect(article).toMatchObject({
+                author: expect.any(String),
+                title: expect.any(String),
+                article_id: expect.any(Number),
+                topic: expect.any(String),
+                created_at: expect.any(String),
+                votes: expect.any(Number),
+                article_img_url: expect.any(String),
+                comment_count: expect.any(String),
+              });
+            });
+          });
+      });
+      test("GET 200: responds with array of articles sorted by created_at in descending order", () => {
+        return request(app)
+          .get("/api/articles")
+          .expect(200)
+          .then(({ body }) => {
+            const { articles } = body;
+            expect(articles).toBeSortedBy("created_at", { descending: true });
+          });
+      });
     });
   });
 });

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const {
   getAllTopics,
   getEndpoints,
   getArticleById,
+  getAllArticles,
 } = require("./controllers/controllers");
 
 const app = express();
@@ -14,6 +15,7 @@ app.get("/api/healthcheck", healthCheck);
 app.get("/api/topics", getAllTopics);
 app.get("/api", getEndpoints);
 app.get("/api/articles/:article_id", getArticleById);
+app.get("/api/articles", getAllArticles);
 
 app.use((err, req, res, next) => {
   if (err.status && err.msg) {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,8 @@
-const { selectTopics, selectArticleById } = require("../models/models");
+const {
+  selectTopics,
+  selectArticleById,
+  selectAllArticles,
+} = require("../models/models");
 const endpoints = require("../endpoints.json");
 
 function healthCheck(req, res, next) {
@@ -30,4 +34,16 @@ function getArticleById(req, res, next) {
   }
 }
 
-module.exports = { healthCheck, getAllTopics, getEndpoints, getArticleById };
+function getAllArticles(req, res, next) {
+  return selectAllArticles().then((articles) => {
+    res.status(200).send({ articles });
+  });
+}
+
+module.exports = {
+  healthCheck,
+  getAllTopics,
+  getEndpoints,
+  getArticleById,
+  getAllArticles,
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -29,18 +29,19 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "description": "serves an array of all articles, default ordered by created_at descending, not including body, including comment_count",
+    "queries": [],
     "exampleResponse": {
       "articles": [
         {
+          "article_id": 5,
           "title": "Seafood substitutions are increasing",
           "topic": "cooking",
           "author": "weegembump",
-          "body": "Text from the article..",
           "created_at": "2018-05-30T15:59:13.341Z",
           "votes": 0,
-          "comment_count": 6
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": "6"
         }
       ]
     }

--- a/models/models.js
+++ b/models/models.js
@@ -23,4 +23,21 @@ function selectArticleById(articleId) {
     });
 }
 
-module.exports = { selectTopics, selectArticleById };
+function selectAllArticles() {
+  return db
+    .query(
+      `
+    SELECT articles.author, title, articles.article_id, topic, articles.created_at, articles.votes, article_img_url, 
+    COUNT(comments.article_id) AS comment_count
+    FROM articles
+    LEFT JOIN comments 
+    ON articles.article_id = comments.article_id 
+    GROUP BY comments.article_id, articles.article_id 
+    ORDER BY articles.created_at DESC ;`
+    )
+    .then(({ rows }) => {
+      return rows;
+    });
+}
+
+module.exports = { selectTopics, selectArticleById, selectAllArticles };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4",
         "supertest": "^6.3.4"
       }
@@ -3252,6 +3253,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7567,6 +7574,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4",
     "supertest": "^6.3.4"
   },
@@ -34,7 +35,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
get /api/articles end point retrieves all articles and presents them by default ordered by created_at in descending order. Includes a count (comment_count) of the number of comments associated with each article. Includes all article properties except body.

error handling considers invalid path.

/api endpoint updated with information on this endpoint.