### PR TITLE
task 20: add pagination to GET /api/articles

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,6 @@ app.use(express.json());
 app.use("/api", apiRouter);
 app.use(customErrorHandler);
 app.use(psqlErrorHandler);
-app.use(displayError);
+// app.use(displayError);
 
 module.exports = app;

--- a/endpoints.json
+++ b/endpoints.json
@@ -30,8 +30,8 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles, default ordered by created_at descending, not including body, including comment_count. Can specify a topic value to filter the output, a sort_by key and order key to sort and order the returned array",
-    "queries": ["topic", "sort_by", "order"],
+    "description": "serves an array of all articles not including 'body' but including 'comment_count', default ordered by 'created_at' descending. Can specify a 'topic' value to filter the output by the requested topic; 'sort_by' and 'order' keys to sort and order the returned array; a 'limit' key to set the maximum number of articles returned in the array; and a 'p' key which works in combination with 'limit' to enable pages of articles to be returned each of length 'limit'. p=1 for the first page etc. Returns a total_count of all of the articles in the database after any filter has been applied but discounting any 'limit' or 'p' set.",
+    "queries": ["topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
         {
@@ -44,7 +44,8 @@
           "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
           "comment_count": 6
         }
-      ]
+      ],
+      "total_count": 15
     }
   },
   "POST /api/articles": {

--- a/errors/index.js
+++ b/errors/index.js
@@ -9,6 +9,8 @@ function customErrorHandler(err, req, res, next) {
 function psqlErrorHandler(err, req, res, next) {
   switch (err.code) {
     case "22P02":
+    case "2201W":
+    case "2201X":
       res.status(400).send({ msg: "bad request" });
       break;
     case "42601":


### PR DESCRIPTION
add 'limit' and 'p' queries to GET /api/articles endpoint enabling the pagination of returned objects. 'limit' sets the maximum number of objects returned in a request and 'p' works in conjunction with 'limit' to enable pages of objects to be requested, each of length 'limit'. Default 'limit' value is 10 if 'limit' has been specified but not set, and default 'p' value is 1 if it has not been specified or if not set. If 'limit' is not specified then all articles are returned. First page is p=1. Add total_count property to response, equal to the total number of articles corresponding to the request, after any filters have been applied but ignoring the pagination keys.

error handling considers 'limit' and 'p' keys which are of the wrong type or out of range, and working in conjunction with other query keys. 

GET /api endpoint updated with a description of these features