### PR TITLE
task 21: add pagination function to get /api/articles/:article_id/comments endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -733,6 +733,144 @@ describe("/api/articles", () => {
           });
       });
     });
+    describe("GET ?limit & p", () => {
+      test("GET 200: retrieves 10 comments when limit is specified but no value set", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit")
+          .expect(200)
+          .then(({ body: { comments } }) => {
+            expect(comments.length).toBe(10);
+          })
+          .then(() => {
+            return request(app)
+              .get("/api/articles/1/comments?limit=")
+              .expect(200)
+              .then(({ body: { comments } }) => {
+                expect(comments.length).toBe(10);
+              });
+          });
+      });
+      test("GET 200: retrieves number of comments requested when limit is specified with a value set", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=7")
+          .then(({ body: { comments } }) => {
+            expect(comments.length).toBe(7);
+          });
+      });
+      test("GET 200: retrieves no comments when limit is specified with a value set to 0", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=0")
+          .then(({ body: { comments } }) => {
+            expect(comments).toEqual([]);
+          });
+      });
+      test("GET 200: retrieves all comments when limit is specified with a value greater than the total number of comments in the database for the specified article", () => {
+        return request(app)
+          .get("/api/articles/3/comments?limit=20")
+          .then(({ body: { comments } }) => {
+            expect(comments.length).toBe(2);
+          });
+      });
+      test("GET 200: retrieves first 10 comments when limit is specified but no value set and p is specified as 1", () => {
+        let firstComment = {};
+        return request(app)
+          .get("/api/articles/1/comments")
+          .then(({ body: { comments } }) => {
+            firstComment = comments[0];
+          })
+          .then(() => {
+            return request(app)
+              .get("/api/articles/1/comments?limit&p=1")
+              .expect(200)
+              .then(({ body: { comments } }) => {
+                expect(comments.length).toBe(10);
+                expect(comments[0]).toEqual(firstComment);
+              });
+          });
+      });
+      test("GET 200: retrieves last 1 comment when limit is specified but no value set and p is specified as 2", () => {
+        let eleventhComment = {};
+        return request(app)
+          .get("/api/articles/1/comments")
+          .then(({ body: { comments } }) => {
+            eleventhComment = comments[10];
+          })
+          .then(() => {
+            return request(app)
+              .get("/api/articles/1/comments?limit&p=2")
+              .expect(200)
+              .then(({ body: { comments } }) => {
+                expect(comments.length).toBe(1);
+                expect(comments[0]).toEqual(eleventhComment);
+              });
+          });
+      });
+      test("GET 200: retrieves last 3 comments when limit is specified as 8 and p is specified as 2", () => {
+        let ninethComment = {};
+        return request(app)
+          .get("/api/articles/1/comments")
+          .then(({ body: { comments } }) => {
+            ninethComment = comments[8];
+          })
+          .then(() => {
+            return request(app)
+              .get("/api/articles/1/comments?limit=8&p=2")
+              .expect(200)
+              .then(({ body: { comments } }) => {
+                expect(comments.length).toBe(3);
+                expect(comments[0]).toEqual(ninethComment);
+              });
+          });
+      });
+      test("GET 200: returns 200 and empty array when limit is specified as 10 and p is specified as 3", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit&p=3")
+          .expect(200)
+          .then(({ body: { comments } }) => {
+            expect(comments).toEqual([]);
+          });
+      });
+      test("GET 400: returns 400 and msg 'bad request' when limit is given an invalid value (wrong type)", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=invalid_type")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("bad request");
+          });
+      });
+      test("GET 400: returns 400 and msg 'bad request' when limit is given an invalid value (out of range)", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=-1")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("bad request");
+          });
+      });
+      test("GET 400: returns 400 and msg 'bad request' when p is specified as invalid (wrong type)", () => {
+        return request(app)
+          .get("/api/articles/1/comments?p=invalid")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("bad request");
+          });
+      });
+      test("GET 400: returns 400 and msg 'bad request' when p is specified as invalid (out of range)", () => {
+        return request(app)
+          .get("/api/articles/3/comments?p=-1")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("bad request");
+          })
+          .then(() => {
+            return request(app)
+              .get("/api/articles/5/comments?p=0")
+              .expect(400)
+              .then(({ body: { msg } }) => {
+                expect(msg).toBe("bad request");
+              });
+          });
+      });
+    });
     describe("POST", () => {
       test("POST 201: returns 201 and the inserted comment object when sent a valid comment object", () => {
         const article_id = 1;

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -64,9 +64,21 @@ function getArticles(req, res, next) {
 }
 
 function getCommentsByArticleId(req, res, next) {
+  const validQueries = ["limit", "p"];
+  const queryKeys = Object.keys(req.query);
+  if (queryKeys.some((query) => !validQueries.includes(query))) {
+    next({ status: 400, msg: "bad data" });
+  }
   const { article_id } = req.params;
+  let { limit, p } = req.query;
+  if (queryKeys.includes("limit") && !limit) {
+    limit = 10;
+  }
+  if (queryKeys.includes("p") && p <= 0) {
+    next({ status: 400, msg: "bad request" });
+  }
   return Promise.all([
-    selectCommentsByArticleId(article_id),
+    selectCommentsByArticleId(article_id, limit, p),
     selectArticleById(article_id),
   ])
     .then(([comments]) => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -30,7 +30,7 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles not including 'body' but including 'comment_count', default ordered by 'created_at' descending. Can specify a 'topic' value to filter the output by the requested topic; 'sort_by' and 'order' keys to sort and order the returned array; a 'limit' key to set the maximum number of articles returned in the array; and a 'p' key which works in combination with 'limit' to enable pages of articles to be returned each of length 'limit'. p=1 for the first page etc. Returns a total_count of all of the articles in the database after any filter has been applied but discounting any 'limit' or 'p' set.",
+    "description": "serves an array of all articles not including 'body' but including 'comment_count', default ordered by 'created_at' descending. Can specify a 'topic' value to filter the output by the requested topic; 'sort_by' and 'order' keys to sort and order the returned array; a 'limit' key to set the maximum number of articles returned in the array; and a 'p' key which works in combination with 'limit' to enable pages of articles to be returned each of length 'limit'. Default 'limit' value is 10 if 'limit' is specified, otherwise all articles are returned. p=1 for the first page etc. If 'p' is not specified or not set then it is set to a default of 1. Returns a total_count of all of the articles in the database after any filter has been applied but discounting any 'limit' or 'p' set.",
     "queries": ["topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
@@ -72,7 +72,8 @@
     }
   },
   "GET /api/articles/:article_id/comments": {
-    "description": "serves an array of all comment objects corresponding to article_id, default ordered by created_at descending",
+    "description": "serves an array of all comment objects corresponding to article_id, default ordered by created_at descending. Accepts a 'limit' key to set the maximum number of comments returned in the array; and a 'p' key which works in combination with 'limit' to enable pages of comments to be returned each of length 'limit'. Default 'limit' value is 10 if 'limit' is specified, otherwise all comments are returned. p=1 for the first page etc. If 'p' is not specified or not set then it is set to a default of 1. ",
+    "queries": ["limit", "p"],
     "exampleResponse": {
       "comments": [
         {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -31,7 +31,7 @@ function selectArticles(
   sortBy = "created_at",
   order = "DESC",
   limit = null,
-  pageNum = "1"
+  pageNum = 1
 ) {
   const validOrder = ["ASC", "DESC"];
   const validSortKeys = [
@@ -61,14 +61,16 @@ function selectArticles(
   });
 }
 
-function selectCommentsByArticleId(articleId) {
+function selectCommentsByArticleId(articleId, limit = null, pageNum = 1) {
+  const offset = --pageNum * (limit ? limit : 0);
   return db
     .query(
       `
     SELECT * FROM comments 
     WHERE article_id = $1 
-    ORDER BY created_at DESC ;`,
-      [articleId]
+    ORDER BY created_at DESC 
+    LIMIT $2 OFFSET $3 ;`,
+      [articleId, limit, offset]
     )
     .then(({ rows }) => {
       return rows;


### PR DESCRIPTION
endpoint updated to enable pagination using 'limit' and 'p' queries. 'limit' sets the maximum number of comments returned, defaulting to 10 if specified but not set. 'p' enables selection of a page of comments of length 'limit', starting at p=1. If 'limit' is specified and p is not specified or not set then it defaults to 1.

error handling considers 'limit' and 'p' being of the wrong type or out of range.

get /api endpoint updated to describe this feature.