### PR TITLE
task 23: delete /api/articles/:article_id and get /api/comments/comment_id endpoints

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -296,6 +296,56 @@ describe("/api/articles", () => {
           });
       });
     });
+    describe("DELETE", () => {
+      test("DELETE 204: returns status 204 and no content when valid article_id sent", () => {
+        return request(app)
+          .delete("/api/articles/1")
+          .expect(204)
+          .then(({ body }) => {
+            expect(body).toEqual({});
+          });
+      });
+      test("DELETE 204: removes given article from database when valid article_id sent", () => {
+        return request(app)
+          .delete("/api/articles/1")
+          .then(() => {
+            return request(app)
+              .get("/api/articles/1")
+              .expect(404)
+              .then(({ body: { msg } }) => {
+                expect(msg).toBe("not found");
+              });
+          });
+      });
+      test("DELETE 204: removes all comments associated with deleted article from database when valid article_id sent", () => {
+        return request(app)
+          .delete("/api/articles/3")
+          .then(() => {
+            return request(app)
+              .get("/api/comments/10")
+              .expect(404)
+              .then(() => {
+                return request(app).get("/api/comments/11").expect(404);
+              });
+          });
+      });
+      test("DELETE 400: returns status 400 and message 'bad request' when invalid article_id sent", () => {
+        return request(app)
+          .delete("/api/articles/invalid_article_id")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("bad request");
+          });
+      });
+      test("DELETE 404: returns status 404 and message 'not found' when article_id is valid but does not exist in the database", () => {
+        return request(app)
+          .delete("/api/articles/9999")
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("not found");
+          });
+      });
+    });
   });
   describe("/api/articles", () => {
     describe("GET", () => {
@@ -1187,6 +1237,31 @@ describe("/api/articles", () => {
           });
       });
     });
+    describe("GET", () => {
+      test("GET 200: returns 200 and the requested comment object", () => {
+        return request(app)
+          .get("/api/comments/1")
+          .expect(200)
+          .then(({ body: { comment } }) => {
+            expect(comment).toMatchObject({
+              comment_id: 1,
+              body: "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+              votes: 16,
+              author: "butter_bridge",
+              article_id: 9,
+              created_at: expect.any(String),
+            });
+          });
+      });
+      test("GET 404: returns 404 and msg 'not found' when the requested comment does not exist in the database", () => {
+        return request(app)
+          .get("/api/comments/9999")
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("not found");
+          });
+      });
+    });
   });
   describe("/api/users", () => {
     describe("GET", () => {
@@ -1206,29 +1281,29 @@ describe("/api/articles", () => {
           });
       });
     });
-    describe("/api/users/:username", () => {
-      describe("GET", () => {
-        test("GET 200: returns 200 and a user object with the properties of username, avatar_url and name with the values equal to the username which was sent", () => {
-          return request(app)
-            .get("/api/users/lurker")
-            .expect(200)
-            .then(({ body: { user } }) => {
-              expect(user).toMatchObject({
-                username: "lurker",
-                name: "do_nothing",
-                avatar_url:
-                  "https://www.golenbock.com/wp-content/uploads/2015/01/placeholder-user.png",
-              });
+  });
+  describe("/api/users/:username", () => {
+    describe("GET", () => {
+      test("GET 200: returns 200 and a user object with the properties of username, avatar_url and name with the values equal to the username which was sent", () => {
+        return request(app)
+          .get("/api/users/lurker")
+          .expect(200)
+          .then(({ body: { user } }) => {
+            expect(user).toMatchObject({
+              username: "lurker",
+              name: "do_nothing",
+              avatar_url:
+                "https://www.golenbock.com/wp-content/uploads/2015/01/placeholder-user.png",
             });
-        });
-        test("GET 404: returns 404 and a msg 'not found' when sent a username which doesnt exist in the database", () => {
-          return request(app)
-            .get("/api/users/invalid_username")
-            .expect(404)
-            .then(({ body: { msg } }) => {
-              expect(msg).toBe("not found");
-            });
-        });
+          });
+      });
+      test("GET 404: returns 404 and a msg 'not found' when sent a username which doesnt exist in the database", () => {
+        return request(app)
+          .get("/api/users/invalid_username")
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("not found");
+          });
       });
     });
   });

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -7,6 +7,7 @@ const {
   checkUserExists,
   insertArticle,
   countArticles,
+  deleteArticle,
 } = require("../models/articles.models");
 const { checkTopicExists } = require("../models/topics.models");
 const endpoints = require("../endpoints.json");
@@ -128,6 +129,18 @@ function postArticle(req, res, next) {
     });
 }
 
+function deleteArticleById(req, res, next) {
+  const { article_id } = req.params;
+
+  return deleteArticle(article_id)
+    .then(() => {
+      res.status(204).send({});
+    })
+    .catch((err) => {
+      next(err);
+    });
+}
+
 module.exports = {
   healthCheck,
   getEndpoints,
@@ -137,4 +150,5 @@ module.exports = {
   postCommentByArticleId,
   patchArticleById,
   postArticle,
+  deleteArticleById,
 };

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -32,4 +32,16 @@ function patchCommentById(req, res, next) {
     });
 }
 
-module.exports = { deleteCommentById, patchCommentById };
+function getCommentById(req, res, next) {
+  const { comment_id } = req.params;
+
+  return selectCommentById(comment_id)
+    .then((comment) => {
+      res.status(200).send({ comment });
+    })
+    .catch((err) => {
+      next(err);
+    });
+}
+
+module.exports = { deleteCommentById, patchCommentById, getCommentById };

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -1,10 +1,10 @@
-const format = require('pg-format');
-const db = require('../connection');
+const format = require("pg-format");
+const db = require("../connection");
 const {
   convertTimestampToDate,
   createRef,
   formatComments,
-} = require('./utils');
+} = require("./utils");
 
 const seed = ({ topicData, userData, articleData, commentData }) => {
   return db
@@ -52,7 +52,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
       CREATE TABLE comments (
         comment_id SERIAL PRIMARY KEY,
         body VARCHAR NOT NULL,
-        article_id INT REFERENCES articles(article_id) NOT NULL,
+        article_id INT NOT NULL REFERENCES articles(article_id) ON DELETE CASCADE,
         author VARCHAR REFERENCES users(username) NOT NULL,
         votes INT DEFAULT 0 NOT NULL,
         created_at TIMESTAMP DEFAULT NOW()
@@ -60,13 +60,13 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
     })
     .then(() => {
       const insertTopicsQueryStr = format(
-        'INSERT INTO topics (slug, description) VALUES %L;',
+        "INSERT INTO topics (slug, description) VALUES %L;",
         topicData.map(({ slug, description }) => [slug, description])
       );
       const topicsPromise = db.query(insertTopicsQueryStr);
 
       const insertUsersQueryStr = format(
-        'INSERT INTO users ( username, name, avatar_url) VALUES %L;',
+        "INSERT INTO users ( username, name, avatar_url) VALUES %L;",
         userData.map(({ username, name, avatar_url }) => [
           username,
           name,
@@ -80,7 +80,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
     .then(() => {
       const formattedArticleData = articleData.map(convertTimestampToDate);
       const insertArticlesQueryStr = format(
-        'INSERT INTO articles (title, topic, author, body, created_at, votes, article_img_url) VALUES %L RETURNING *;',
+        "INSERT INTO articles (title, topic, author, body, created_at, votes, article_img_url) VALUES %L RETURNING *;",
         formattedArticleData.map(
           ({
             title,
@@ -97,11 +97,11 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
       return db.query(insertArticlesQueryStr);
     })
     .then(({ rows: articleRows }) => {
-      const articleIdLookup = createRef(articleRows, 'title', 'article_id');
+      const articleIdLookup = createRef(articleRows, "title", "article_id");
       const formattedCommentData = formatComments(commentData, articleIdLookup);
 
       const insertCommentsQueryStr = format(
-        'INSERT INTO comments (body, author, article_id, votes, created_at) VALUES %L;',
+        "INSERT INTO comments (body, author, article_id, votes, created_at) VALUES %L;",
         formattedCommentData.map(
           ({ body, author, article_id, votes = 0, created_at }) => [
             body,

--- a/endpoints.json
+++ b/endpoints.json
@@ -129,6 +129,22 @@
       }
     }
   },
+  "DELETE /api/articles/:article_id": {
+    "description": "deletes the requested article and all comments associated with it. Returns 204 and empty object",
+    "exampleResponse": {}
+  },
+  "GET /api/comments/:comment_id": {
+    "description": "returns the comment object specified",
+    "queries": [],
+    "exampleResponse": {
+      "comment_id": 7,
+      "body": "I hate streaming noses",
+      "votes": 11,
+      "author": "icellusedkars",
+      "article_id": 1,
+      "created_at": 1604437200000
+    }
+  },
   "DELETE /api/comments/:comment_id": {
     "description": "deletes the given comment in the database, returns 204 and no body content.",
     "exampleResponse": {}

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -138,6 +138,22 @@ function countArticles(topic = "%") {
   });
 }
 
+function deleteArticle(articleId) {
+  return db
+    .query(
+      `
+    DELETE FROM articles 
+    WHERE article_id = $1 
+    RETURNING *;`,
+      [articleId]
+    )
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "not found" });
+      }
+    });
+}
+
 module.exports = {
   selectArticleById,
   selectArticles,
@@ -147,4 +163,5 @@ module.exports = {
   checkUserExists,
   insertArticle,
   countArticles,
+  deleteArticle,
 };

--- a/routes/articles-router.js
+++ b/routes/articles-router.js
@@ -6,12 +6,14 @@ const {
   postCommentByArticleId,
   patchArticleById,
   postArticle,
+  deleteArticleById,
 } = require("../controllers/articles.controllers");
 
 articlesRouter.get("/", getArticles);
 articlesRouter.post("/", postArticle);
 articlesRouter.get("/:article_id", getArticleById);
 articlesRouter.patch("/:article_id", patchArticleById);
+articlesRouter.delete("/:article_id", deleteArticleById);
 articlesRouter.get("/:article_id/comments", getCommentsByArticleId);
 articlesRouter.post("/:article_id/comments", postCommentByArticleId);
 

--- a/routes/comments-router.js
+++ b/routes/comments-router.js
@@ -2,9 +2,11 @@ const commentsRouter = require("express").Router();
 const {
   deleteCommentById,
   patchCommentById,
+  getCommentById,
 } = require("../controllers/comments.controllers");
 
 commentsRouter.delete("/:comment_id", deleteCommentById);
 commentsRouter.patch("/:comment_id", patchCommentById);
+commentsRouter.get("/:comment_id", getCommentById);
 
 module.exports = commentsRouter;


### PR DESCRIPTION
delete /api/articles/article_id endpoint deletes the requested article returning 204 and an empty object. All comments referencing that article_id are also deleted.

get /api/comments/comment_id endpoint added to enable proper testing of the cascading delete from removing the article.

error handling for each endpoint considers invalid article_id (wrong type) or not existing in the database.

get /api endpoint updated to include the two new endpoints